### PR TITLE
Remove or neutralize react 19 prop types

### DIFF
--- a/default.mjs
+++ b/default.mjs
@@ -245,6 +245,10 @@ export const reactConfig = [
 			"react/require-default-props": [ "warn", { classes: "defaultProps", functions: "defaultArguments" } ],
 			"react/self-closing-comp": "error",
 			"react/void-dom-elements-no-children": "error",
+
+			// Removed in React 19 (https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-proptypes-and-defaultprops).
+			// But still in the recommended rules (https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/prop-types.md).
+			"react/prop-types": "off",
 		},
 	},
 ];

--- a/default.mjs
+++ b/default.mjs
@@ -241,7 +241,8 @@ export const reactConfig = [
 			"react/no-unused-prop-types": "error",
 			"react/no-unused-state": "error",
 			"react/prefer-es6-class": "error",
-			"react/require-default-props": [ "error", { ignoreFunctionalComponents: true } ],
+			// This will turn into an `error` in the future. It's a warning to give us time to adapt.
+			"react/require-default-props": [ "warn", { classes: "defaultProps", functions: "defaultArguments" } ],
 			"react/self-closing-comp": "error",
 			"react/void-dom-elements-no-children": "error",
 		},


### PR DESCRIPTION
## Context
In React 18.3, in preparation for React 19, the prop types are deprecated.
Specifically, `propTypes` and `defaultProps` will be removed for functions (though `defaultProps` will continue to be supported for class components)

https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis


We should adapt accordingly. I'm not entirely sure if that also mean the prop-types package will be unsupported.
Either way, we should:
* remove our linting rule that requires propTypes (and defaultProps when not required).
* refactor our `defaultProps` to be handled by defaults in the object instead. E.g. move to inline ES6.

We talked about it in the tech-council, see [the meeting notes](https://docs.google.com/document/d/1hhAjEpCBXr7xyIwIc22CeAB9X8oBUxvwB6f5Ldp2Ui4/edit#heading=h.25qhbc71excu). 

ESLint Rules
* [`react/require-default-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/require-default-props.md)
* [`react/prop-types`](https://github.com/jsx-eslint/eslint-plugin-react/blob/v7.37.5/docs/rules/prop-types.md)



Fixes https://github.com/Yoast/reserved-tasks/issues/551