### PR TITLE
Remove `no-undefined` rule

### DIFF
--- a/default.mjs
+++ b/default.mjs
@@ -92,7 +92,6 @@ export default [
 			"no-script-url": "error",
 			"no-shadow": [ "error", { builtinGlobals: false, hoist: "all", allow: [] } ],
 			"no-undef-init": "error",
-			"no-undefined": "error",
 			"no-unneeded-ternary": "error",
 			"no-unused-expressions": "error",
 			"no-useless-call": "error",


### PR DESCRIPTION
## Summary
- Removes the `no-undefined` ESLint rule from the default configuration

The rule is outdated for modern JavaScript development. Since ES5+, `undefined` is read-only in the global scope, making the rule's original purpose (preventing shadowing) unnecessary. Using `undefined` directly is more readable than alternatives like `void 0`.

## Test plan
- [x] Verify the config still loads without errors
- [x] Run ESLint with the updated config on a project

🤖 Generated with [Claude Code](https://claude.com/claude-code)