### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+permissions:
+  id-token: write  # Required for OIDC to publish to NPM
+  contents: read
+
 jobs:
   check:
     name: Lint
@@ -31,7 +35,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: yarn
+          registry-url: 'https://registry.npmjs.org'
       - run: yarn install --frozen-lockfile
-      - run: yarn publish --verbose --access public
-        env:
-          YARN_AUTH_TOKEN: ${{secrets.NPM_JS_YOASTBOT_PUBLISH_ACCESS_TOKEN}}
+      # Ensure npm 11.5.1 or later is installed - this is needed for OIDC support
+      - name: Update npm
+        run: npm install -g npm@latest
+      - run: npm publish --verbose --access public


### PR DESCRIPTION
Fixes #2 
Apply same fix as https://github.com/Yoast/ai-insights-frontend/pull/226
Trusted publisher has been added in npm.